### PR TITLE
Metal LB and NGINX ingress controller for exposing services using ingresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@ Instructions and playbooks for setting up a k8s cluster
 
 - [cluster](./cluster): everything needed for the cluster itself
 - [storage](./storage): components for local storage class and nfs storage with a provisioner
+- [metallb](./metallb): network load balancer configuration for the bare metal cluster
 - [echo](./echo): a dummy echo service deployment for demo purposes

--- a/echo/echo-server.yaml
+++ b/echo/echo-server.yaml
@@ -12,7 +12,7 @@ metadata:
   name: echo-server
   namespace: echo
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: echo-server
@@ -36,9 +36,29 @@ metadata:
   namespace: echo
 spec:
   ports:
-    - name: http-port
+    - name: 8080-echo
       port: 8080
-      targetPort: http-port
       protocol: TCP
+      targetPort: 8080
   selector:
     app: echo-server
+  type: ClusterIP
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: echo-ingress
+  namespace: echo
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /echo
+            pathType: Prefix
+            backend:
+              service:
+                name: echo-server
+                port:
+                  number: 8080

--- a/ingress-nginx/README.md
+++ b/ingress-nginx/README.md
@@ -6,5 +6,6 @@ helm upgrade ingress-nginx ingress-nginx/ingress-nginx \
     --install \
     --namespace ingress-nginx \
     --create-namespace \
-    --version "4.4.0"
+    --version "4.4.0" \
+    --values ingress-nginx/nginx-values.yaml
 ```

--- a/ingress-nginx/README.md
+++ b/ingress-nginx/README.md
@@ -1,1 +1,10 @@
 ## NGINX ingress controller
+Install the ingress controller using helm
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm upgrade ingress-nginx ingress-nginx/ingress-nginx \
+    --install \
+    --namespace ingress-nginx \
+    --create-namespace \
+    --version "4.4.0"
+```

--- a/ingress-nginx/README.md
+++ b/ingress-nginx/README.md
@@ -1,0 +1,1 @@
+## NGINX ingress controller

--- a/ingress-nginx/nginx-values.yaml
+++ b/ingress-nginx/nginx-values.yaml
@@ -1,0 +1,8 @@
+controller:
+  hostNetwork: true
+  hostPort:
+    enabled: true
+    ports:
+      http: 80
+      https: 443
+  kind: DaemonSet

--- a/metallb/README.md
+++ b/metallb/README.md
@@ -1,0 +1,14 @@
+# metal lb
+Install [MetalLB](https://metallb.universe.tf/) using the official helm chart
+```bash
+helm repo add metallb https://metallb.github.io/metallb
+helm upgrade metallb metallb/metallb \
+    -i \
+    --namespace metallb-system \
+    --create-namespace \
+    --version "0.13.7"
+```
+Set up layer 2 mode
+```bash
+kubectl apply -f metallb/layer2.yaml
+```

--- a/metallb/layer2.yaml
+++ b/metallb/layer2.yaml
@@ -1,0 +1,15 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 10.1.1.140-10.1.1.159
+
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default-pool-ad
+  namespace: metallb-system

--- a/metallb/layer2.yaml
+++ b/metallb/layer2.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   addresses:
   - 10.10.10.0/24
+  autoAssign: true
 
 ---
 apiVersion: metallb.io/v1beta1

--- a/metallb/layer2.yaml
+++ b/metallb/layer2.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-  - 10.1.1.140-10.1.1.159
+  - 10.10.10.0/24
 
 ---
 apiVersion: metallb.io/v1beta1

--- a/metallb/layer2.yaml
+++ b/metallb/layer2.yaml
@@ -1,16 +1,19 @@
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
-  name: default-pool
+  name: default
   namespace: metallb-system
 spec:
   addresses:
-  - 10.10.10.0/24
+  - 192.168.88.100/26
   autoAssign: true
 
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
-  name: default-pool-ad
+  name: default
   namespace: metallb-system
+spec:
+  ipAddressPools:
+  - default

--- a/storage/README.md
+++ b/storage/README.md
@@ -3,11 +3,12 @@
 To use dynamic storage via NFS, install the [nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) by
 ```bash
 helm repo add nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
-helm install nfs-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
+helm upgrade nfs-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
+    -i \
     --namespace nfs-provisioner \
     --create-namespace \
     --version "4.0.17" \
-    --values nfs-values.yaml
+    --values storage/nfs-values.yaml
 ```
 
 or a local storage class if you want all the hassle

--- a/storage/nfs-values.yaml
+++ b/storage/nfs-values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 2
+replicaCount: 1
 storageClass:
   name: nfs
   defaultClass: true


### PR DESCRIPTION
The ingress controller successfully created a "load balancer" and using the echo server I tested that the requests are routed correctly from the same network
<pre>
$ kubectl get svc ingress-nginx-controller -n ingress-nginx
NAME                       TYPE           CLUSTER-IP       <b>EXTERNAL-IP</b>     PORT(S)                      AGE
ingress-nginx-controller   LoadBalancer   10.102.225.165   <b>192.168.88.64</b>   80:32172/TCP,443:31417/TCP   57m
</pre>

<pre>
$ curl http://<b>192.168.88.64</b>/echo/hello-world
Request served by echo-server-64b8d7d9c6-gfd9c

HTTP/1.1 GET /echo/hello-world

Host: 192.168.88.64
Accept: */*
User-Agent: curl/7.68.0
X-Forwarded-For: 192.168.88.232
X-Forwarded-Host: 192.168.88.64
X-Forwarded-Port: 80
X-Forwarded-Proto: http
X-Forwarded-Scheme: http
X-Real-Ip: 192.168.88.232
X-Request-Id: 465263cd0fbdb0afaad822f956612048
X-Scheme: http
</pre>